### PR TITLE
Rename module to keycloak_client_scope_mapping.

### DIFF
--- a/lib/ansible/modules/identity/keycloak/keycloak_client_scope_mapping.py
+++ b/lib/ansible/modules/identity/keycloak/keycloak_client_scope_mapping.py
@@ -15,7 +15,7 @@ ANSIBLE_METADATA = {
 
 DOCUMENTATION = '''
 ---
-module: keycloak_client_scope
+module: keycloak_client_scope_mapping
 
 short_description: Allows administration of Keycloak scope mappings via the Keycloak REST API
 
@@ -147,7 +147,7 @@ author:
 EXAMPLES = '''
 - name: Add realm roles to a client scope mapping (using implicit default of acting on a client and setting realm scope mappings)
   local_action:
-    module: keycloak_client_scope
+    module: keycloak_client_scope_mapping
     auth_client_id: admin-cli
     auth_keycloak_url: https://auth.example.com/auth
     auth_realm: master
@@ -163,7 +163,7 @@ EXAMPLES = '''
 
 - name: Add client roles to a client-template scope mapping
   local_action:
-    module: keycloak_client_scope
+    module: keycloak_client_scope_mapping
     auth_client_id: admin-cli
     auth_keycloak_url: https://auth.example.com/auth
     auth_realm: master
@@ -182,7 +182,7 @@ EXAMPLES = '''
 
 - name: Remove client role testrole01 for testclient01 from testclienttemplate
   local_action:
-    module: keycloak_client_scope
+    module: keycloak_client_scope_mapping
     auth_client_id: admin-cli
     auth_keycloak_url: https://auth.example.com/auth
     auth_realm: master
@@ -199,7 +199,7 @@ EXAMPLES = '''
 
 - name: Remove all client roles from testclient01 using exclusive and an empty client role dict
   local_action:
-    module: keycloak_client_scope
+    module: keycloak_client_scope_mapping
     auth_client_id: admin-cli
     auth_keycloak_url: https://auth.example.com/auth
     auth_realm: master


### PR DESCRIPTION
##### SUMMARY
Could this module be renamed to keycloak_client_scope_mapping?

As of Keycloak 4.0 there are "client scopes" at the realm level, with a top level menu entry for "client scope". This module manages the mapping of client scopes to clients (and client templates, although those are removed in KeyCloak >= 4.0 in favor of default default client scopes). I would like to add a module for these client scopes as keycloak_client_scope. Therefore, I think it would make sense to rename this module into keycloak_client_scope_mapping.

Aside from that, I have tested this module against Keycloak 4.8 & 6.0 (after having renamed the module) and I am looking forward to the module making it into Ansible.

See #35558

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
keycloak_client_scope_mapping

##### ANSIBLE VERSION
```
ansible 2.8.1
```
